### PR TITLE
Incorrect Service Account in GitOps 1.2.1, prevents application from deploying

### DIFF
--- a/cluster/namespace/openshift-gitops-argocd-cluster-argocd-application-controller.yaml
+++ b/cluster/namespace/openshift-gitops-argocd-cluster-argocd-application-controller.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: admin
 subjects:
 - kind: ServiceAccount
-  name: openshift-gitops-argocd-cluster-argocd-application-controller
+  name: openshift-gitops-argocd-application-controller
   namespace: openshift-gitops

--- a/cluster/namespace/openshift-gitops-argocd-cluster-argocd-application-controller.yaml
+++ b/cluster/namespace/openshift-gitops-argocd-cluster-argocd-application-controller.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spring-petclinic-application-contoller-role-binding
+  namespace: spring-petclinic
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-cluster-argocd-application-controller
+  namespace: openshift-gitops


### PR DESCRIPTION
This Service Account is needed in the namespace in Gitops 1.2.1. This allow the demo application to deploy with no issues.

