### PR TITLE
update RBAC for Managed Openshifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Once OpenShift GitOps is installed, an instance of Argo CD is automatically inst
 Argo CD upon installation generates an initial admin password which is stored in a Kubernetes secret. In order to retrieve this password, run the following command to decrypt the admin password:
 
 ```
-oc extract secret/argocd-cluster-cluster -n openshift-gitops --to=-
+oc extract secret/openshift-gitops-cluster -n openshift-gitops --to=-
 ```
 
 Click on Argo CD from the OpenShift Web Console application launcher and then log into Argo CD with `admin` username and the password retrieved from the previous step.


### PR DESCRIPTION
I've only tested this on ROKS (Managed OpenShift) in IBM cloud.

When you install the OpenShift GitOps Operator, if on ROKS, whilst you can login to ArgoCD via the route or via the button in the app launcher, you cannot create a new app in ArgoCD because the SSO account doesn't have admin rights.  it isn't part of system:cluster-admins

**Case 1:**

the default ArgoCD RBAC contained in the the CM resource argocd-rbac-cm  that is created when the instance is installed has RBAC such as this
  rbac:
    policy: |
      g, system:cluster-admins, role:admin
      g, cluster-admins, role:admin
    scopes: '[groups]'

However, the user account you are using is not part of system:cluster-admins, and in IBM cloud ROKS, cluster-admins does not exist.

to make this work in the In the case of the default installation of argoCD I created a new group called cluster-admins and placed my account in that group

**Case 2**

in a non default ArgoCD (one where the user instructs the Operator to create a new argoCD instance the default RBAC appears to be  
  rbac:
    policy: |
      g, system:cluster-admins, role:admin
    scopes: '[groups]'

However, the user account you are using is not part of system:cluster-admins,
to make this work I changed the RBAC to look as follows

  rbac:
    policy: |
      g, system:cluster-admins, role:admin
      g, cluster-admins, role:admin
    scopes: '[groups]'

and then I ensured I have a. group created a called cluster-admins and placed my account was placed in that group.


